### PR TITLE
Revert "add json-browser API format" and add ?textplain=true doc

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -20,7 +20,7 @@ Une API a été développée pour offrir un accès Open Data simplifié aux donn
 
 ## Explications
 
-- **Format :** La plupart des exemples fournis ci-dessous sont donnés au format XML pour permettre plus de lisibilité dans le navigateur web. Veuillez remplacer `xml` en `json` ou `csv` pour accéder aux autres formats. Il éxiste aussi un format `json-browser` qui vous permet d'afficher le fichier dans le navigateur.
+- **Format :** La plupart des exemples fournis ci-dessous sont donnés au format XML pour permettre plus de lisibilité dans le navigateur web. Veuillez remplacer `xml` en `json` ou `csv` pour accéder aux autres formats. Pour forcer l'affichage dans le navigateur, vous pouvez utilisez l'option `?textplain=true`.
 
 - **Encoding :** les données sont proposées en `utf-8`. Si vous vous retrouvez face à des caractères kabbalistiques, cela signifie qu'il vous faut régler l'encodage dans les options du logiciel avec lequel vous manipulez les données. Si votre tableur ne vous permet de spécifier l'encodage, vous pouvez rajouter l'option `?withBOM=true` à la fin des adresses des fichiers CSV que vous cherchez à télécharger.
 

--- a/lib/model/doctrine/myTools.class.php
+++ b/lib/model/doctrine/myTools.class.php
@@ -481,11 +481,6 @@ class myTools {
           $action->getResponse()->setHttpHeader('content-disposition', 'attachment; filename="'.$filename.'.json"');
         }
         break;
-      case 'json-browser':
-        if (!$request->getParameter('textplain')) {
-          $action->getResponse()->setContentType('text/plain; charset=utf-8');
-        }
-        break;
       case 'xml':
         if (!$request->getParameter('textplain')) {
           $action->getResponse()->setContentType('text/xml; charset=utf-8');


### PR DESCRIPTION
This reverts commit 97c6ce35b8eaec5c6f586ee9041200cc4afd51b1 since there's already an argument to do the same thing (also the commit didn't work finally). Also adds this option to the API doc.