### PR TITLE
Parlementaires apparentés

### DIFF
--- a/apps/frontend/modules/parlementaire/templates/_photoParlementaire.php
+++ b/apps/frontend/modules/parlementaire/templates/_photoParlementaire.php
@@ -5,7 +5,13 @@ if (isset($flip) && $flip)
   $add = '&flip='.$flip;
 if (!$parlementaire->isEnMandat())
   $groupe = " -- (ancien".($parlementaire->sexe == "F" ? "ne" : "")." député".($parlementaire->sexe == "F" ? "e" : "").')';
-else if ($parlementaire->groupe_acronyme) $groupe = " -- (Groupe parlementaire : ".$parlementaire->groupe_acronyme.')';
+else if ($parlementaire->groupe_acronyme) {
+  $apparente = '';
+  if (preg_match('/apparent/', $parlementaire->getGroupe()->getFonction())) {
+    $apparente = 'app. ';
+  }
+  $groupe = " -- (Groupe parlementaire : ".$apparente.$parlementaire->groupe_acronyme.')';
+}
 $abs = '';
 if (isset($absolute) && $absolute)
   $abs = 'absolute=true';

--- a/lib/model/doctrine/Parlementaire.class.php
+++ b/lib/model/doctrine/Parlementaire.class.php
@@ -111,6 +111,10 @@ class Parlementaire extends BaseParlementaire
         $groupe = " ".link_to($this->groupe_acronyme, '@list_parlementaires_groupe?acro='.$this->groupe_acronyme);
       else $groupe = " ".$this->groupe_acronyme;
     }
+    if (preg_match('/apparent/', $this->groupe->getFonction())) {
+      if ($this->sexe == 'F') $groupe = ' apparentée'.$groupe;
+      else $groupe = ' apparenté'.$groupe;
+    }
     return $statut.$type.$groupe;
   }
 


### PR DESCRIPTION
Afin de répondre à la demande de François Bonhomme de voir le statuts d'apparenté à un groupe mieux mis en valeur : 
 - ajoute "député apparenté XXX"  dans le titre de la/les page(s) du député
 - ajoute "député apparenté XXX" dans les tableaux des députés
 - préfixe l'acronyme du groupe parlementaire par "app." dans le hover des images