### PR TITLE
update manual install docs

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -190,7 +190,7 @@ Solr est le moteur de recherche utilisé dans le projet. Il s'installe sur un mo
  * Installer tomcat6 :
 
     ```bash
-    sudo apt install tomcat8
+    sudo aptitude install tomcat6
     ```
 
  * Préparer le dossier d'accueil des données Solr :

--- a/doc/install.md
+++ b/doc/install.md
@@ -201,12 +201,6 @@ Solr est le moteur de recherche utilisé dans le projet. Il s'installe sur un mo
     <dataDir>/MON/REPERTOIRE/lib/vendor/SolrServer/solr/data</dataDir>
     ```
 
-    * Et faire de même dans `bin/db.inc`:
-
-    ```bash
-    SOLR_DATA_PATH="$PATH_APP/lib/vendor/SolrServer/solr/data"
-    ```
-
  * S'assurer que ce répertoire data soit accessible en écriture par l'utilisateur tomcat6 (ou tomcatXX suivant votre version de Tomcat) :
 
     ```bash

--- a/doc/install.md
+++ b/doc/install.md
@@ -17,7 +17,7 @@ Pour le parsing :
 
 ```bash
 sudo aptitude install libwww-mechanize-perl libfile-path-perl
-sudo aptitude install libxml2-devel libxslt-devel python-devel
+sudo aptitude install libxml2-devel libxslt-devel python-devel python-pip
 sudo pip install bs4 lxml html5lib requests
 ```
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -6,6 +6,7 @@ Sous une distribution type Ubuntu, installer les packages suivants :
 
 ```bash
 sudo apt-get install git
+sudo apt-get install git tasksel
 sudo tasksel install lamp-server php5-cli
 sudo apt-get install phpmyadmin # optionnel mais recommandé
 sudo apt-get install imagemagick php5-imagick # Pour la carte des circonscriptions
@@ -189,7 +190,7 @@ Solr est le moteur de recherche utilisé dans le projet. Il s'installe sur un mo
  * Installer tomcat6 :
 
     ```bash
-    sudo aptitude install tomcat6
+    sudo apt install tomcat8
     ```
 
  * Préparer le dossier d'accueil des données Solr :


### PR DESCRIPTION
After doing a following `install.md` on elementary OS 5.0 Juno (based on Ubuntu 18.04.2 LTS), I foun a few things to improve.

Included in this PR:

- `tasksel` is not available by default on Elementary OS so include it in the required dependencies
- no need to update the SOLR_DATA_PATH, it's already set at the right value
- `python-pip` in not in the parser dependencies but is needed to install `requests` & co

Other things I found but didn't include in this PR:

- the `php5-gd` package was not available
- `aptitude` is not available too (simply replaced with `apt`)
- creation of the mysql database and user could be a included as a SQL command:
```
sudo mysql -u root -p
CREATE DATABASE cpc;
USE cpc;
CREATE USER 'cpc'@'localhost' IDENTIFIED BY 'cpc';
GRANT ALL PRIVILEGES ON * . * TO 'cpc'@'localhost';
FLUSH PRIVILEGES;
```
- `tomcat6` not available too, now it's `tomcat8`