### PR TITLE
Delegration range : scrutins pendant le covid

### DIFF
--- a/lib/model/doctrine/Scrutin.class.php
+++ b/lib/model/doctrine/Scrutin.class.php
@@ -142,7 +142,7 @@ class Scrutin extends BaseScrutin
           throw new Exception("Could not set vote metadata: {$data}");
         }
 
-        if ($has_delegations || (self::DEBUT_DELEGATIONS <= $this->Seance->date && $this->Seance->date <= self::FIN_DELEGATIONS)) {
+        if ($has_delegations || $this->isPartOfDelegationsRanges()) {
           $parlscrutin->updatePresence();
         }
 
@@ -152,5 +152,20 @@ class Scrutin extends BaseScrutin
         echo "ERREUR scrutin {$this->id}, parl $id_an: {$e->getMessage()}\n";
       }
     }
+  }
+
+  const DELEGATIONS_INDEX_DEBUT = 0;
+  const DELEGATIONS_INDEX_FIN = 1;
+  public function getDelegationsRanges() {
+      return array(
+          array(self::DEBUT_DELEGATIONS, self::FIN_DELEGATIONS)
+      );
+  }
+  public function isPartOfDelegationsRanges() {
+      $is_part = false;
+      foreach($this->getDelegationsRanges() as $range) {
+          $is_part |= ($range[self::DELEGATIONS_INDEX_DEBUT] <= $this->Seance->date && $this->Seance->date <= $range[self::DELEGATIONS_INDEX_FIN]);
+      }
+      return $is_part;
   }
 }

--- a/lib/model/doctrine/Scrutin.class.php
+++ b/lib/model/doctrine/Scrutin.class.php
@@ -2,12 +2,6 @@
 
 class Scrutin extends BaseScrutin
 {
-  // Date début délégations (cf https://github.com/regardscitoyens/nosdeputes.fr/pull/115#issuecomment-421844588 )
-  // On ne génère pas de preuve de présence à partir des votes avant cette date sauf si le scrutin a des délégations (3 cas particuliers de solennel)
-  const DEBUT_DELEGATIONS = '2018-03-20';
-  // Anticipe potentiel recul de la transparence en matière de publicité des délégations
-  const FIN_DELEGATIONS = '9999-99-99';
-
   public function getLinkSource() {
     return "http://www2.assemblee-nationale.fr/scrutins/detail/(legislature)/"
          . myTools::getLegislature()
@@ -154,17 +148,10 @@ class Scrutin extends BaseScrutin
     }
   }
 
-  const DELEGATIONS_INDEX_DEBUT = 0;
-  const DELEGATIONS_INDEX_FIN = 1;
-  public function getDelegationsRanges() {
-      return array(
-          array(self::DEBUT_DELEGATIONS, self::FIN_DELEGATIONS)
-      );
-  }
   public function isPartOfDelegationsRanges() {
       $is_part = false;
-      foreach($this->getDelegationsRanges() as $range) {
-          $is_part |= ($range[self::DELEGATIONS_INDEX_DEBUT] <= $this->Seance->date && $this->Seance->date <= $range[self::DELEGATIONS_INDEX_FIN]);
+      foreach(ScrutinTable::getInstance()->getDelegationsRanges() as $range) {
+          $is_part |= ($range[ScrutinTable::DELEGATIONS_INDEX_DEBUT] <= $this->Seance->date && $this->Seance->date <= $range[ScrutinTable::DELEGATIONS_INDEX_FIN]);
       }
       return $is_part;
   }

--- a/lib/model/doctrine/ScrutinTable.class.php
+++ b/lib/model/doctrine/ScrutinTable.class.php
@@ -11,14 +11,13 @@ class ScrutinTable extends Doctrine_Table
 
     // Date début délégations (cf https://github.com/regardscitoyens/nosdeputes.fr/pull/115#issuecomment-421844588 )
     // On ne génère pas de preuve de présence à partir des votes avant cette date sauf si le scrutin a des délégations (3 cas particuliers de solennel)
-    const DEBUT_DELEGATIONS = '2018-03-20';
-    // Anticipe potentiel recul de la transparence en matière de publicité des délégations
-    const FIN_DELEGATIONS = '9999-99-99';
+    // Avec le covid, les votes par délégations ont été systématisés et leur publication a été arrêtée
     const DELEGATIONS_INDEX_DEBUT = 0;
     const DELEGATIONS_INDEX_FIN = 1;
     public function getDelegationsRanges() {
         return array(
-            array(self::DEBUT_DELEGATIONS, self::FIN_DELEGATIONS),
+            array('2018-03-20', '2020-03-10'), //début de la publication des délégations de vote
+            array('2020-06-29', '9999-99-99')  //suspension pendant le covid de la publication des délégations
         );
     }
 

--- a/lib/model/doctrine/ScrutinTable.class.php
+++ b/lib/model/doctrine/ScrutinTable.class.php
@@ -17,7 +17,7 @@ class ScrutinTable extends Doctrine_Table
     public function getDelegationsRanges() {
         return array(
             array('2018-03-20', '2020-03-10'), //début de la publication des délégations de vote
-            array('2020-06-29', '9999-99-99')  //suspension pendant le covid de la publication des délégations
+            array('2020-06-20', '9999-99-99')  //reprise après suspension pendant le covid de la publication des délégations
         );
     }
 

--- a/lib/model/doctrine/ScrutinTable.class.php
+++ b/lib/model/doctrine/ScrutinTable.class.php
@@ -8,4 +8,18 @@ class ScrutinTable extends Doctrine_Table
     {
         return Doctrine_Core::getTable('Scrutin');
     }
+
+    // Date début délégations (cf https://github.com/regardscitoyens/nosdeputes.fr/pull/115#issuecomment-421844588 )
+    // On ne génère pas de preuve de présence à partir des votes avant cette date sauf si le scrutin a des délégations (3 cas particuliers de solennel)
+    const DEBUT_DELEGATIONS = '2018-03-20';
+    // Anticipe potentiel recul de la transparence en matière de publicité des délégations
+    const FIN_DELEGATIONS = '9999-99-99';
+    const DELEGATIONS_INDEX_DEBUT = 0;
+    const DELEGATIONS_INDEX_FIN = 1;
+    public function getDelegationsRanges() {
+        return array(
+            array(self::DEBUT_DELEGATIONS, self::FIN_DELEGATIONS),
+        );
+    }
+
 }


### PR DESCRIPTION
Permet d'exclure les scrutins qui ont eu lieu pendant la suspension de la publication des délégations durant le covid.