### PR TITLE
Get rid of a warning

### DIFF
--- a/lib/vendor/symfony/lib/exception/sfException.class.php
+++ b/lib/vendor/symfony/lib/exception/sfException.class.php
@@ -100,7 +100,7 @@ class sfException extends Exception
         }
       }
 
-      ob_start(sfConfig::get('sf_compressed') ? 'ob_gzhandler' : '');
+      ob_start(sfConfig::get('sf_compressed') ? 'ob_gzhandler' : null);
 
       header('HTTP/1.0 500 Internal Server Error');
     }


### PR DESCRIPTION
`Warning: ob_start(): function '' not found or invalid function name in <...>/lib/vendor/symfony/lib/exception/sfException.c`