### PR TITLE
Set json response as application/json if textplain

### DIFF
--- a/lib/model/doctrine/myTools.class.php
+++ b/lib/model/doctrine/myTools.class.php
@@ -547,6 +547,8 @@ class myTools {
         if (!$request->getParameter('textplain')) {
           $action->getResponse()->setContentType('text/plain; charset=utf-8');
           $action->getResponse()->setHttpHeader('content-disposition', 'attachment; filename="'.$filename.'.json"');
+        } else {
+          $action->getResponse()->setContentType('application/json; charset=utf-8');
         }
         break;
       case 'xml':


### PR DESCRIPTION
On Firefox, if the content type is json, it shows a pretty interface to easily explore the data

If it was me, I would make this the default (without textplain) but here's a more conservative PR