### PR TITLE
Migration des champs serialisés en PHP vers du json

### DIFF
--- a/apps/backend/modules/organisme/actions/actions.class.php
+++ b/apps/backend/modules/organisme/actions/actions.class.php
@@ -254,8 +254,10 @@ class organismeActions extends autoOrganismeActions
         if (!$option) {
           $option = new VariableGlobale();
           $option->setChamp('commissions');
-          $option->setValue(serialize($corresp));
-        } else $option->setValue(serialize(array_merge(unserialize($option->getValue()), $corresp)));
+          $option->setValue($corresp);
+        } else {
+          $option->mergeValue($corresp);
+        }
         $option->save();
 
         if ($this->article && $this->article->object_id == $this->bad) {

--- a/apps/frontend/modules/api/actions/actions.class.php
+++ b/apps/frontend/modules/api/actions/actions.class.php
@@ -41,7 +41,7 @@ class apiActions extends sfActions
     $date = preg_replace('/^(\d{2})(\d{2})$/', '20\\1\\2', $date);
     $d[1] = preg_replace('/^(\d{2})$/', '20\\1', $d[1]);
     $vg = Doctrine::getTable('VariableGlobale')->findOneByChamp('stats_month_'.$d[1].'_'.$d[2]);
-    $top = unserialize($vg->value);
+    $top = $vg->value;
     $this->forward404Unless($top);
 
     $this->res = array();
@@ -309,15 +309,15 @@ class apiActions extends sfActions
       $res['groupes_parlementaires'] = myTools::array2hash($parl->getGroupes(), 'responsabilite');
       $res['historique_responsabilites'] = myTools::array2hash($parl->getHistorique(), 'responsabilite');
     }
-    $res['sites_web'] = myTools::array2hash(unserialize($parl->sites_web), 'site');
-    $res['emails'] = myTools::array2hash(unserialize($parl->mails), 'email');
+    $res['sites_web'] = myTools::array2hash($parl->getSitesWeb(), 'site');
+    $res['emails'] = myTools::array2hash($parl->getMails(), 'email');
     if ($light != 2) {
-      $res['adresses'] = myTools::array2hash(unserialize($parl->adresses), 'adresse');
-      $res['collaborateurs'] = myTools::array2hash(unserialize($parl->collaborateurs), 'collaborateur');
-      $res['autres_mandats'] = myTools::array2hash(unserialize($parl->autres_mandats), 'mandat');
-      $res['anciens_autres_mandats'] = myTools::array2hash(unserialize($parl->anciens_autres_mandats), 'mandat');
+      $res['adresses'] = myTools::array2hash($parl->getAdresses(), 'adresse');
+      $res['collaborateurs'] = myTools::array2hash($parl->getCollaborateurs(), 'collaborateur');
+      $res['autres_mandats'] = myTools::array2hash($parl->getAutresMandats(), 'mandat');
+      $res['anciens_autres_mandats'] = myTools::array2hash($parl->getAnciensAutresMandats(), 'mandat');
     }
-    $res['anciens_mandats'] = myTools::array2hash(unserialize($parl->anciens_mandats), 'mandat');
+    $res['anciens_mandats'] = myTools::array2hash($parl->getAnciensMandats(), 'mandat');
     $res['profession'] = $parl->profession;
     $res['place_en_hemicycle'] = $parl->place_hemicycle;
     $res['url_an'] = $parl->url_an;
@@ -325,13 +325,13 @@ class apiActions extends sfActions
     $res['slug'] = $parl->getSlug();
     $res['url_nosdeputes'] = myTools::url_forAPI('@parlementaire?slug='.$res['slug']);
     $res['url_nosdeputes_api'] = myTools::url_forAPI('api/parlementaire?format='.$format.'&slug='.$res['slug']);
-    $mandats = unserialize($parl->getAutresMandats());
+    $mandats = $parl->getAutresMandats();
     if (!$mandats) {
 	    $mandats = array();
     }
     $res['nb_mandats'] = count($mandats);
     $res['twitter'] = "";
-    if ($parl->sites_web) foreach (unserialize($parl->sites_web) as $site)
+    if ($parl->sites_web) foreach ($parl->getSitesWeb() as $site)
       if (preg_match("/twitter.com/", $site))
         $res['twitter'] = str_replace("https://twitter.com/", "", $site);
     return $res;
@@ -382,7 +382,7 @@ class apiActions extends sfActions
     $this->forward404Unless($secid);
 
     if ($option = Doctrine::getTable('VariableGlobale')->findOneByChamp('linkdossiers')) {
-      $links = unserialize($option->getValue());
+      $links = $option->getValue();
       if (isset($links[$secid]))
         $secid = $links[$secid];
     }

--- a/apps/frontend/modules/parlementaire/actions/actions.class.php
+++ b/apps/frontend/modules/parlementaire/actions/actions.class.php
@@ -102,7 +102,7 @@ class parlementaireActions extends sfActions
     }
 
     $anciens_mandats = array();
-    foreach (unserialize($this->parlementaire->getAnciensMandats()) as $m)
+    foreach ($this->parlementaire->getAnciensMandats() as $m)
       if (preg_match("#^((\d+)/(\d+)/(\d+)) / (.*) / (.*)$#", $m, $match)) {
         if ($match[5] != "")
           $anciens_mandats[] = "$match[4]$match[3]$match[2]".ucfirst($this->parlementaire->getParlFonction())." du $match[1] au $match[5] ($match[6])";
@@ -488,7 +488,7 @@ class parlementaireActions extends sfActions
 
     $this->tops = array();
     foreach($parlementaires as $p) {
-      $tops = unserialize($p['top']);
+      $tops = VariableGlobale::json_decode_or_unserialize($p['top']);
 
       // En mode bilan final on n'affiche que les députés avec plus de 6 mois de mandat
       if ($fin && $tops['nb_mois'] < 6)

--- a/apps/frontend/modules/parlementaire/templates/_fiche.php
+++ b/apps/frontend/modules/parlementaire/templates/_fiche.php
@@ -34,7 +34,7 @@ if ($cause = $parlementaire->getCauseFinMandat())
   echo '<li><a href="https://fr.wikipedia.org/wiki/'.rawurlencode($parlementaire->nom).'">Page Wikipédia</a></li>';
 if ($parlementaire->sites_web) {
   $moreweb = "";
-  foreach (unserialize($parlementaire->sites_web) as $site) if ($site && !preg_match('/assemblee-nationale\.fr\/deputes\/fiche/', $site) && preg_match('/^http/', $site)) {
+  foreach ($parlementaire->getSitesWeb() as $site) if ($site && !preg_match('/assemblee-nationale\.fr\/deputes\/fiche/', $site) && preg_match('/^http/', $site)) {
     $nomsite = "Site web : ".$site;
     if (preg_match('/twitter/', $site)) $nomsite = "Compte Twitter : ".preg_replace("/^.*[^a-z0-9_]([a-z0-9_]+)$/i", "@\\1", $site);
     else if (preg_match('/facebook/', $site)) $nomsite = "Page Facebook";
@@ -48,9 +48,9 @@ if ($parlementaire->sites_web) {
       </ul>
 
   <?php if (!$ministre) :
-    $mails = unserialize($parlementaire->mails);
-    $adresses = unserialize($parlementaire->adresses);
-    $collabs = unserialize($parlementaire->collaborateurs); ?>
+    $mails = $parlementaire->getMails();
+    $adresses = $parlementaire->getAdresses();
+    $collabs = $parlementaire->getCollaborateurs(); ?>
     <h2>Contact</h2>
       <ul>
         <li>Par e-mail :

--- a/apps/frontend/modules/parlementaire/templates/photoSuccess.php
+++ b/apps/frontend/modules/parlementaire/templates/photoSuccess.php
@@ -27,7 +27,7 @@ if ($ratio > $width/$height)
 else $width2 = $height*$ratio;
 $iorig = imagecreatefromjpeg($file);
 $ih = imagecreatetruecolor($work_height*$ratio, $work_height);
-if (!$color && ((!$parlementaire->isEnMandat() && !myTools::isFinlegislature()) || preg_match('/décè/i', $parlementaire->getAnciensMandats())))
+if (!$color && ((!$parlementaire->isEnMandat() && !myTools::isFinlegislature()) || preg_match('/décè/i', $parlementaire->getAnciensMandats(true))))
   parlementaireActions::imagetograyscale($iorig);
 imagecopyresampled($ih, $iorig, 0, 0, max(0, ($width - $width2)/2), max(0, ($height - $height2)/2), $work_height*$ratio, $work_height, $width2, $height2);
 $width = $work_height*$ratio;

--- a/apps/frontend/modules/plot/actions/components.class.php
+++ b/apps/frontend/modules/plot/actions/components.class.php
@@ -145,7 +145,7 @@ class plotComponents extends sfComponents
     );
     $presences_medi = Doctrine::getTable('VariableGlobale')->findOneByChamp('presences_medi');
     if ($presences_medi) {
-      $prmedi = unserialize($presences_medi->value);
+      $prmedi = $presences_medi->getValue();
       $debut_legis = strtotime(myTools::getDebutLegislature());
       $an_legis = date('o', $debut_legis);
       $sem_legis = date('W', $debut_legis);
@@ -314,7 +314,7 @@ class plotComponents extends sfComponents
 
     $stats = Doctrine::getTable('VariableGlobale')->findOneByChamp('stats_groupes');
     if ($stats)
-      $stats = unserialize($stats->value);
+      $stats = $stats->getValue();
     $lastyear = date('Y-m-d', time()-60*60*24*365);
 
     // Collecte les dernières appartenances de députés à un groupe pour afficher la proportion de députés de chaque groupe sur l'ensemble de la période plutôt que sur le moment

--- a/apps/frontend/modules/section/actions/actions.class.php
+++ b/apps/frontend/modules/section/actions/actions.class.php
@@ -53,7 +53,7 @@ class sectionActions extends sfActions
     $secid = $request->getParameter('id');
     $this->forward404Unless($secid);
     if ($option = Doctrine::getTable('VariableGlobale')->findOneByChamp('linkdossiers')) {
-      $links = unserialize($option->getValue());
+      $links = $option->getValue();
       if (isset($links[$secid]))
         $secid = $links[$secid];
     }

--- a/lib/model/doctrine/Citoyen.class.php
+++ b/lib/model/doctrine/Citoyen.class.php
@@ -37,7 +37,8 @@ class Citoyen extends BaseCitoyen
   }
 
   public function getParametres() {
-    $a = unserialize($this->_get('parametres'));
+    $p = $this->_get('parametres');
+    $a = VariableGlobale::json_decode_or_unserialize($p);
     if (!is_array($a)) {
       $a = array();
     }
@@ -47,6 +48,6 @@ class Citoyen extends BaseCitoyen
     if (!empty($array) && !is_array($array)) {
       throw new Exception('Parametres requires an array');
     }
-    if(is_array($array)) { return $this->_set('parametres', serialize($array)); }
+    if(is_array($array)) { return $this->_set('parametres', json_encode($array)); }
   }
 }

--- a/lib/model/doctrine/OrganismeTable.class.php
+++ b/lib/model/doctrine/OrganismeTable.class.php
@@ -8,7 +8,7 @@ class OrganismeTable extends Doctrine_Table
     $nom = self::cleanNom($nom);
 
     if ($option = Doctrine::getTable('VariableGlobale')->findOneByChamp('commissions')) {
-      $commissions = unserialize($option->getValue());
+      $commissions = $option->getValue();
       if (isset($commissions[$nom]) && $org = $this->findOneByNom($commissions[$nom]))
         return $org;
       $comcor = str_replace('’', '\'', $nom);

--- a/lib/model/doctrine/Parlementaire.class.php
+++ b/lib/model/doctrine/Parlementaire.class.php
@@ -258,13 +258,31 @@ class Parlementaire extends BaseParlementaire
   }
 
   public function setAutresMandats($array) {
-    $this->_set('autres_mandats', serialize($array));
+    $this->_set('autres_mandats', json_encode($array));
+  }
+  public function getAutresMandats($raw = false) {
+    if ($raw) {
+        return $this->_get('autres_mandats');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('autres_mandats'));
   }
   public function setAnciensMandats($array) {
-    $this->_set('anciens_mandats', serialize($array));
+    $this->_set('anciens_mandats', json_encode($array));
+  }
+  public function getAnciensMandats($raw = false) {
+    if ($raw) {
+        return $this->_get('anciens_mandats');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('anciens_mandats'));
   }
   public function setAnciensAutresMandats($array) {
-    $this->_set('anciens_autres_mandats', serialize($array));
+    $this->_set('anciens_autres_mandats', json_encode($array));
+  }
+  public function getAnciensAutresMandats($raw = false) {
+    if ($raw) {
+        return $this->_get('anciens_autres_mandats');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('anciens_autres_mandats'));
   }
   public function setSuppleantDe($nom) {
     if ($p = doctrine::getTable('Parlementaire')->findOneByNomSexeGroupeCirco($nom))
@@ -274,16 +292,49 @@ class Parlementaire extends BaseParlementaire
     return doctrine::getTable('Parlementaire')->findOneBySuppleantDeId($this->id);
   }
   public function setCollaborateurs($array) {
-    $this->_set('collaborateurs', serialize($array));
+    $this->_set('collaborateurs', json_encode($array));
+  }
+  public function getCollaborateurs($raw = false) {
+    if ($raw) {
+        return $this->_get('collaborateurs');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('collaborateurs'));
   }
   public function setMails($array) {
-    $this->_set('mails', serialize($array));
+    $this->_set('mails', json_encode($array));
+  }
+  public function getMails($raw = false) {
+    if ($raw) {
+        return $this->_get('mails');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('mails'));
   }
   public function setSitesWeb($array) {
-    $this->_set('sites_web', serialize($array));
+    $this->_set('sites_web', json_encode($array));
+  }
+  public function getSitesWeb($raw = false) {
+    if ($raw) {
+        return $this->_get('sites_web');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('sites_web'));
   }
   public function setAdresses($array) {
-    $this->_set('adresses', serialize($array));
+    $this->_set('adresses', json_encode($array));
+  }
+  public function getAdresses($raw = false) {
+    if ($raw) {
+        return $this->_get('adresses');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('adresses'));
+  }
+  public function setTop($array) {
+    $this->_set('top', json_encode($array));
+  }
+  public function getTop($raw = false) {
+    if ($raw) {
+        return $this->_get('top');
+    }
+    return VariableGlobale::json_decode_or_unserialize($this->_get('top'));
   }
   public function getGroupe() {
     foreach($this->getOrganismes() as $po) {
@@ -714,10 +765,6 @@ class Parlementaire extends BaseParlementaire
     else return 0;
   }
 
-  public function getTop() {
-    return unserialize($this->_get('top'));
-  }
-
   public function isEnMandat() {
     return (!$this->fin_mandat || $this->fin_mandat < $this->debut_mandat);
   }
@@ -726,7 +773,7 @@ class Parlementaire extends BaseParlementaire
     if (preg_match('/(\d{4})-(\d{2})-(\d{2})/', $this->fin_mandat, $m))
       $fin =  $m[3].'/'.$m[2].'/'.$m[1];
     else return null;
-    foreach (unserialize($this->getAnciensMandats()) as $m)
+    foreach ($this->getAnciensMandats() as $m)
       if (preg_match("/^(.*) \/ (.*) \/ (.*)$/", $m, $match))
         if ($match[2] === $fin) return $match[3];
     return null;
@@ -737,7 +784,7 @@ class Parlementaire extends BaseParlementaire
     $debut = strtotime(myTools::getDebutLegislature());
     $fin = min($debut + (5*365-31)*24*3600, time());  # fin législature définie à 4 ans et 11 mois)
     $semaines = 0;
-    foreach (unserialize($this->getAnciensMandats()) as $m) {
+    foreach ($this->getAnciensMandats() as $m) {
       if (preg_match("/^(.*) \/ (.*) \/ (.*)$/", $m, $match)) {
         $match[1] = preg_replace("#^(\d+)/(\d+)/(\d+)$#", "\\3-\\2-\\1", $match[1]);
         $sta = strtotime($match[1]);
@@ -764,7 +811,7 @@ class Parlementaire extends BaseParlementaire
   public function getMandatsLegislature() {
     $mandats = array();
     $debut = strtotime(myTools::getDebutLegislature());
-    foreach (unserialize($this->getAnciensMandats()) as $m) {
+    foreach ($this->getAnciensMandats() as $m) {
       if (preg_match("/^(.*) \/ (.*) \/ (.*)$/", $m, $match)) {
         $match[1] = preg_replace("#^(\d+)/(\d+)/(\d+)$#", "\\3-\\2-\\1", $match[1]);
         if ($match[2] != "")

--- a/lib/model/doctrine/Seance.class.php
+++ b/lib/model/doctrine/Seance.class.php
@@ -15,7 +15,7 @@ class Seance extends BaseSeance
   public static function identifySession($date) {
     if (!self::$debut_session) {
       $session = Doctrine::getTable('VariableGlobale')->findOneByChamp('session');
-      self::$debut_session = unserialize($session->value);
+      self::$debut_session = $session->getValue();
     }
     if (!is_array(self::$debut_session))
 	return ;

--- a/lib/model/doctrine/VariableGlobale.class.php
+++ b/lib/model/doctrine/VariableGlobale.class.php
@@ -5,5 +5,49 @@
  */
 class VariableGlobale extends BaseVariableGlobale
 {
+    public static function isSerialized($v) {
+        if (!$v) {
+            return false;
+        }
+        return (in_array($v[0], ['a', 'i', 's']) && $v[1] == ':');
+    }
+    public static function isJsonEncoded($v) {
+        if (!$v) {
+            return false;
+        }
+        return in_array($v[0], ['{', '"', '[']);
+    }
 
+    public static function json_decode_or_unserialize($v) {
+        if (self::isSerialized($v)) {
+            return unserialize($v);
+        }
+        if (self::isJsonEncoded($v)) {
+            return json_decode($v, true);
+        }
+        if (!$v) {
+            return null;
+        }
+        print_r($v);exit;
+        throw new sfException('value not unserializable');
+    }
+
+    function getValue($raw = false) {
+        $v = $this->_get('value');
+        if ($raw) {
+            return $v;
+        }
+        return VariableGlobale::json_decode_or_unserialize($v);
+    }
+
+    public function setValue($v, $serialized = false) {
+        if (  $serialized || ( is_string($v) && ( self::isSerialized($v) || self::isJsonEncoded($v) ) ) ) {
+            return $this->_set('value', $v);
+        }
+        return $this->_set('value', json_encode($v));
+    }
+
+    public function mergeValue($v) {
+        return $this->_set('value', json_encode(array_merge($option->getValue(), $corresp)));
+    }
 }

--- a/lib/model/doctrine/myTools.class.php
+++ b/lib/model/doctrine/myTools.class.php
@@ -130,8 +130,9 @@ class myTools {
   public static function getVacances() {
     $vacances = array();
     $vacs = Doctrine::getTable('VariableGlobale')->findOneByChamp('vacances');
-    if ($vacs)
-      $vacances = unserialize($vacs->value);
+    if ($vacs) {
+      $vacances = $vacs->getValue();
+    }
     unset($vacs);
     return $vacances;
   }

--- a/lib/task/addParlSiteTask.class.php
+++ b/lib/task/addParlSiteTask.class.php
@@ -22,7 +22,7 @@ class addParlSiteTask extends sfBaseTask {
     $site = $arguments['site'];
     $sites = array();
     if ($parl->sites_web)
-      foreach (unserialize($parl->sites_web) as $s)
+      foreach ($parl->getSitesWeb() as $s)
         if ($site !== $s)
           $sites[] = $s;
     $sites[] = $site;

--- a/lib/task/fuseDossiersTask.class.php
+++ b/lib/task/fuseDossiersTask.class.php
@@ -113,8 +113,10 @@ class fuseDossiersTask extends sfBaseTask {
     if (!$option) {
       $option = new VariableGlobale();
       $option->setChamp('dossiers');
-      $option->setValue(serialize($corresp));
-    } else $option->setValue(serialize(array_merge(unserialize($option->getValue()), $corresp)));
+      $option->setValue($corresp);
+    } else {
+      $option->mergeValue($corresp);
+    }
     $option->save();
     print_r($corresp);
     print "  ";
@@ -122,11 +124,11 @@ class fuseDossiersTask extends sfBaseTask {
     if (!$option) {
       $option = new VariableGlobale();
       $option->setChamp('linkdossiers');
-      $option->setValue(serialize(array("$bad->id" => "$good->id")));
+      $option->setValue(array("$bad->id" => "$good->id"));
     } else {
-      $value = unserialize($option->getValue());
+      $value = $option->getValue();
       $value["$bad->id"] = "$good->id";
-      $option->setValue(serialize($value));
+      $option->setValue($value);
     }
     $option->save();
     print "$bad->id => $good->id\n";

--- a/lib/task/printCommissionsTask.class.php
+++ b/lib/task/printCommissionsTask.class.php
@@ -12,7 +12,7 @@ class printCommissionsTask extends sfBaseTask {
   protected function execute($arguments = array(), $options = array()) {
     $manager = new sfDatabaseManager($this->configuration);
     $option = Doctrine::getTable('VariableGlobale')->findOneByChamp('commissions');
-    if ($option) foreach (unserialize($option->getValue()) as $bad => $good)
+    if ($option) foreach ($option->getValue() as $bad => $good)
       echo '"'.$bad.'" => "'.$good.'",'."\n";
   }
 }

--- a/lib/task/printVariableGlobaleTask.class.php
+++ b/lib/task/printVariableGlobaleTask.class.php
@@ -13,7 +13,7 @@ class printVariableGlobaleTask extends sfBaseTask {
   protected function execute($arguments = array(), $options = array()) {
     $manager = new sfDatabaseManager($this->configuration);
     $option = Doctrine::getTable('VariableGlobale')->findOneByChamp($arguments['variable']);
-    if ($option) print_r(unserialize($option->getValue()));
+    if ($option) print_r($option->getValue());
   }
 }
 

--- a/lib/task/removeParlSiteTask.class.php
+++ b/lib/task/removeParlSiteTask.class.php
@@ -22,14 +22,14 @@ class removeParlSiteTask extends sfBaseTask {
     $site = $arguments['site'];
     $sites = array();
     if ($parl->sites_web) {
-      foreach (unserialize($parl->sites_web) as $s) {
+      foreach ($parl->getSitesWeb() as $s) {
         if ($site === $s)
           print "REMOVING $s from websites\n";
         else $sites[] = $s;
       }
     }
     print_r($sites);
-    $parl->sites_web = $sites;
+    $parl->setSitesWeb($sites);
     $parl->save();
   }
 }

--- a/lib/task/setCommissionsTask.class.php
+++ b/lib/task/setCommissionsTask.class.php
@@ -16,9 +16,9 @@ class setCommissionsTask extends sfBaseTask {
  //   $commissions = array();
 
 
-//    $option->setValue(serialize($commissions));
+//    $option->setValue($commissions);
 //    $option->save();
-    print_r(unserialize($option->getValue()));
+    print_r($option->getValue());
   }
 }
 

--- a/lib/task/setParlTwitterTask.class.php
+++ b/lib/task/setParlTwitterTask.class.php
@@ -22,7 +22,7 @@ class setParlTwitterTask extends sfBaseTask {
     print "FOUND parl : ".$parl->nom."\n";
     $sites = array();
     if ($parl->sites_web) {
-      foreach (unserialize($parl->sites_web) as $s) {
+      foreach ($parl->getSitesWeb() as $s) {
         if (preg_match('/twitter.com\//', $s))
           print "REMOVING $s to its websites\n";
         else $sites[] = $s;
@@ -33,7 +33,7 @@ class setParlTwitterTask extends sfBaseTask {
     $turl = "https://twitter.com/$twitter";
     print "ADDING $turl to its websites\n";
     $sites[] = $turl;
-    $parl->sites_web = $sites;
+    $parl->setSitesWeb($sites);
     $parl->save();
   }
 }

--- a/lib/task/setSessionTask.class.php
+++ b/lib/task/setSessionTask.class.php
@@ -23,7 +23,7 @@ class setSessionTask extends sfBaseTask {
       $var = new VariableGlobale();
       $var->champ = 'session';
     }
-    $var->value = serialize($serialize);
+    $var->setValue($serialize);
     $var->save();
   }
 }

--- a/lib/task/setVacancesTask.class.php
+++ b/lib/task/setVacancesTask.class.php
@@ -49,8 +49,8 @@ class setVacancesTask extends sfBaseTask {
     if (!$option) {
       $option = new VariableGlobale();
       $option->setChamp('vacances');
-      $option->setValue(serialize($semaines));
-    } else $option->setValue(serialize($semaines));
+    }
+    $option->setValue($semaines);
     $option->save();
     $option->free();
   }

--- a/lib/task/topDeputesTask.class.php
+++ b/lib/task/topDeputesTask.class.php
@@ -326,7 +326,7 @@ class topDeputesTask extends sfBaseTask
         $globale = new VariableGlobale();
         $globale->champ = 'stats_month_'.$m[1].'_'.$m[2];
       }
-      $globale->value = serialize($this->deputes);
+      $globale->setValue($this->deputes);
       $globale->save();
       return;
     }
@@ -419,7 +419,7 @@ class topDeputesTask extends sfBaseTask
     foreach(array_keys($this->deputes) as $id) {
       $depute = Doctrine::getTable('Parlementaire')->find($id);
       if ($depute) {
-        $depute->top = serialize($this->deputes[$id]);
+        $depute->setTop($this->deputes[$id]);
         $depute->save();
       } else {
         echo "ERREUR: député '$id' non trouvé\n";
@@ -433,7 +433,7 @@ class topDeputesTask extends sfBaseTask
       $globale = new VariableGlobale();
       $globale->champ = 'stats_groupes';
     }
-    $globale->value = serialize($this->groupes);
+    $globale->setValue($this->groupes);
     $globale->save();
 
 
@@ -483,7 +483,7 @@ class topDeputesTask extends sfBaseTask
         $this->executeRapports(clone $qd);
 
         if (isset($this->deputes[$p->id])) {
-          $p->top = serialize($this->deputes[$p->id]);
+          $p->setTop($this->deputes[$p->id]);
           $p->save();
         }
       }
@@ -531,7 +531,7 @@ class topDeputesTask extends sfBaseTask
       $globale2 = new VariableGlobale();
       $globale2->champ = 'presences_medi';
     }
-    $globale2->value = serialize($this->presences_medi);
+    $globale2->setValue($this->presences_medi);
     $globale2->save();
   }
 


### PR DESCRIPTION
Modifie l'enregistrement des champs sérialisés pour stocker du JSON afin de rendre les tables Parlementaire et VariableGlobale moins dépendantes de PHP
Pour permettre la migration, les geters permettent l'accès aux données stockées dans les deux formats (php serialize et json)